### PR TITLE
Added a library search path for NixOS

### DIFF
--- a/glfw.py
+++ b/glfw.py
@@ -163,6 +163,7 @@ else:
                           ['',
                            '/usr/lib64', '/usr/local/lib64',
                            '/usr/lib', '/usr/local/lib',
+                           '/run/current-system/sw/lib',
                            '/usr/lib/x86_64-linux-gnu/'], _glfw_get_version)
 
 if _glfw is None:


### PR DESCRIPTION
Due to the fact that NixOS uses a bit of an obscure file system folder structure, PyGLFW doesn't find the glfw library. I added a path string to the search function to make it work.