### PR TITLE
ENH: Add `sys.prefix`/lib to library search path

### DIFF
--- a/glfw/library.py
+++ b/glfw/library.py
@@ -127,12 +127,13 @@ def _get_library_search_paths():
     """
     search_paths = [
         '',
+        os.path.abspath(os.path.dirname(__file__)),
+        sys.prefix + '/lib',
         '/usr/lib64',
         '/usr/local/lib64',
         '/usr/lib', '/usr/local/lib',
         '/run/current-system/sw/lib',
-        '/usr/lib/x86_64-linux-gnu/',
-        os.path.abspath(os.path.dirname(__file__))
+        '/usr/lib/x86_64-linux-gnu/'
     ]
 
     if sys.platform == 'darwin':


### PR DESCRIPTION
When trying to create a `conda-forge` package of pyGLFW, I realized that it couldn't locate the `glfw` library, which `conda` installs into the `lib` subdirectory of `sys.prefix`. This commit adds this location to the search path. Additionally, it slightly changes the search path order: The priority is now
- current directory
- `pyGLFW` directory
- `sys.prefix`/lib
- "global" locations (`/usr/...` etc.)