### PR TITLE
Fix get_window_content_scale: Pass float pointers

### DIFF
--- a/glfw/__init__.py
+++ b/glfw/__init__.py
@@ -1286,9 +1286,9 @@ if hasattr(_glfw, 'glfwGetWindowContentScale'):
         Wrapper for:
             void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float* yscale);
         """
-        xscale_value = ctypes.c_int(0)
+        xscale_value = ctypes.c_float(0)
         xscale = ctypes.pointer(xscale_value)
-        yscale_value = ctypes.c_int(0)
+        yscale_value = ctypes.c_float(0)
         yscale = ctypes.pointer(yscale_value)
         _glfw.glfwGetWindowContentScale(window, xscale, yscale)
         return xscale_value.value, yscale_value.value


### PR DESCRIPTION
Function expects float pointers, not int pointers https://www.glfw.org/docs/latest/group__window.html#gaf5d31de9c19c4f994facea64d2b3106c