### PR TITLE
ENH: Rework library loading on Win to add better conda support

### DIFF
--- a/glfw/library.py
+++ b/glfw/library.py
@@ -152,21 +152,33 @@ if os.environ.get('PYGLFW_LIBRARY', ''):
     except OSError:
         glfw = None
 elif sys.platform == 'win32':
-    # try glfw3.dll using windows search paths
+    glfw = None  # Will become `not None` on success.
+
+    # try package directory
     try:
-        glfw = ctypes.CDLL('glfw3.dll')
+        if sys.maxsize > 2**32:
+            # load Microsoft Visual C++ 2012 runtime on 64-bit systems
+            msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr110.dll'))
+        else:
+            # load Microsoft Visual C++ 2010 runtime on 32-bit systems
+            msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr100.dll'))
+        glfw = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'glfw3.dll'))
     except OSError:
-        # try glfw3.dll in package directory
+        pass
+
+    # try conda's default location on Windows
+    if glfw is None:
         try:
-            if sys.maxsize > 2**32:
-                # load Microsoft Visual C++ 2012 runtime on 64-bit systems
-                msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr110.dll'))
-            else:
-                # load Microsoft Visual C++ 2010 runtime on 32-bit systems
-                msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr100.dll'))
-            glfw = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'glfw3.dll'))
+            glfw = ctypes.CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'glfw3.dll'))
         except OSError:
-            glfw = None
+            pass
+    
+    # try Windows default search path
+    if glfw is None:
+        try:
+            glfw = ctypes.CDLL('glfw3.dll')
+        except OSError:
+            pass
 else:
     glfw = _load_library(['glfw', 'glfw3'], ['.so', '.dylib'],
                           _get_library_search_paths(), _glfw_get_version)

--- a/glfw/library.py
+++ b/glfw/library.py
@@ -154,29 +154,29 @@ if os.environ.get('PYGLFW_LIBRARY', ''):
 elif sys.platform == 'win32':
     glfw = None  # Will become `not None` on success.
 
-    # try package directory
+    # try Windows default search path
     try:
-        if sys.maxsize > 2**32:
-            # load Microsoft Visual C++ 2012 runtime on 64-bit systems
-            msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr110.dll'))
-        else:
-            # load Microsoft Visual C++ 2010 runtime on 32-bit systems
-            msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr100.dll'))
-        glfw = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'glfw3.dll'))
+        glfw = ctypes.CDLL('glfw3.dll')
     except OSError:
         pass
+
+    # try package directory
+    if glfw is None:
+        try:
+            if sys.maxsize > 2**32:
+                # load Microsoft Visual C++ 2012 runtime on 64-bit systems
+                msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr110.dll'))
+            else:
+                # load Microsoft Visual C++ 2010 runtime on 32-bit systems
+                msvcr = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'msvcr100.dll'))
+            glfw = ctypes.CDLL(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'glfw3.dll'))
+        except OSError:
+            pass
 
     # try conda's default location on Windows
     if glfw is None:
         try:
             glfw = ctypes.CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'glfw3.dll'))
-        except OSError:
-            pass
-    
-    # try Windows default search path
-    if glfw is None:
-        try:
-            glfw = ctypes.CDLL('glfw3.dll')
         except OSError:
             pass
 else:


### PR DESCRIPTION
This PR reworks the library loading on Windows slightly.

I realized that `glfw3.dll` could not be loaded in some `conda` environments. `glfw3.dll` is installed in `sys.prefix/Library/bin/` by `conda`. So I've added this search path.

I've also changed the library search order to (hopefully?) match the order of Linux and macOS:
- first, try the package directory
- then, try the `conda` default installation location
- lastly, try the Windows default search path

Tested to be working on Python 3.6, 3.7, and 3.8.