### PR TITLE
Add a ctypes call to improve hidpi support with multiple monitors.

### DIFF
--- a/glfw/__init__.py
+++ b/glfw/__init__.py
@@ -57,6 +57,13 @@ else:
         exec("raise exception, None, traceback")
 
 
+# Make sure that glfw windows pick up being moved from one monitor to another
+try:
+    ctypes.windll.shcore.SetProcessDpiAwareness(2)
+except Exception:
+    pass  # fail on non-windows / old windows
+
+
 class GLFWError(UserWarning):
     """
     Exception class used for reporting GLFW errors.


### PR DESCRIPTION
I have a setup with a laptop screen and a 4K external display. I found that `get_framebuffer_size` and `get_window_content_scale` produce the correct results when the window is resized. However, when moving the window from monitor to another, the window is not updated. Adding this code fixes that.

This works on Windows 10. I am not sure what it does on older system, but I suppose worst case is that the current behavior is maintained.