### PR TITLE
Fix TypeError(s) when initialising GamePad state

### DIFF
--- a/glfw/__init__.py
+++ b/glfw/__init__.py
@@ -266,8 +266,8 @@ class _GLFWgamepadstate(ctypes.Structure):
 
     def __init__(self):
         ctypes.Structure.__init__(self)
-        self.buttons = (ctypes.c_ubyte * 15)([0] * 15)
-        self.axes = (ctypes.c_float * 6)([0] * 6)
+        self.buttons = (ctypes.c_ubyte * 15)(* [0] * 15)
+        self.axes = (ctypes.c_float * 6)(* [0] * 6)
 
     def wrap(self, gamepad_state):
         """


### PR DESCRIPTION
The initialisers for buttons (and axes) require integer (or float)
arguments, but got arrays instead.

Fixed by unpacking the arrays.

The error happened in a call to get_gamepad_state, but it can be reproduced in the REPL (as can the fix).

```
>>> import ctypes
>>> # Init with zeros creates an instance of c_ubyte_Array_15
... (ctypes.c_ubyte * 15)(0,0,0)
<__main__.c_ubyte_Array_15 object at 0x101f5d7a0>
>>> # Init with an array is a TypeError
... (ctypes.c_ubyte * 15)([0,0,0])
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
TypeError: an integer is required
```