### PR TITLE
fix debug issue for python3

### DIFF
--- a/glfw/library.py
+++ b/glfw/library.py
@@ -71,8 +71,7 @@ def _glfw_get_version(filename):
     Queries and returns the library version tuple or None by using a
     subprocess.
     """
-    is_python3 = sys.version_info.major == 3
-    version_checker_source = f'''
+    version_checker_source = '''
         import sys
         import ctypes
 
@@ -95,7 +94,10 @@ def _glfw_get_version(filename):
             else:
                 return None
 
-        input_func = {'input' if is_python3 else 'raw_input'}
+        try:
+            input_func = raw_input
+        except NameError:
+            input_func = input
         filename = input_func().strip()
 
         try:
@@ -109,7 +111,7 @@ def _glfw_get_version(filename):
 
     args = [sys.executable, '-c', textwrap.dedent(version_checker_source)]
     process = subprocess.Popen(args, universal_newlines=True,
-                               stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                               stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out = process.communicate(filename)[0]
     out = out.strip()
     if out:

--- a/glfw/library.py
+++ b/glfw/library.py
@@ -71,7 +71,8 @@ def _glfw_get_version(filename):
     Queries and returns the library version tuple or None by using a
     subprocess.
     """
-    version_checker_source = '''
+    is_python3 = sys.version_info.major == 3
+    version_checker_source = f'''
         import sys
         import ctypes
 
@@ -94,10 +95,7 @@ def _glfw_get_version(filename):
             else:
                 return None
 
-        try:
-            input_func = raw_input
-        except NameError:
-            input_func = input
+        input_func = {'input' if is_python3 else 'raw_input'}
         filename = input_func().strip()
 
         try:


### PR DESCRIPTION
When running python code which uses pyGLFW in debug mode
the error attached in the image is shown.

it happens since the code in `version_checker_source` cant even compile in python3,
the keyword `raw_input` does not exists.

i added code which plants the right keyword according to the python version

![image](https://user-images.githubusercontent.com/13338950/167260688-0f31dbc5-675b-4779-90f3-1a1636bb7d5a.png)
