### PR TITLE
Prevent error when running in debug mode in vscode

### DIFF
--- a/glfw/library.py
+++ b/glfw/library.py
@@ -130,9 +130,9 @@ def _glfw_get_version(filename):
                 return None
 
         try:
-            input_func = raw_input
-        except NameError:
             input_func = input
+        except NameError:
+            input_func = raw_input
         filename = input_func().strip()
 
         try:


### PR DESCRIPTION
When running code with "run and debug" in VSCode, it fails in a particularly strange way when the code imports glfw. It somehow fails on the `raw_input` not existing.

This is on Mac, have not tested on other platforms yet.

The error is most likely caused by some weird interaction between debugpy (the vscode python debugger) and subprocessing. I strongly suspect this can be regarded as a bug in debugpy, but tracing down that bug is much harder than fixing this particular case 😄 

This simply assumes Python3 and falls back to the Python2 variant if it fails, instead of the other way around.  