### PR TITLE
g/library.py: paths for various architectures.

### DIFF
--- a/glfw/library.py
+++ b/glfw/library.py
@@ -173,6 +173,14 @@ def _get_library_search_paths():
         '/usr/lib/x86_64-linux-gnu/',
         '/usr/lib/aarch64-linux-gnu/',
         '/usr/lib/arm-linux-gnueabihf',
+        '/usr/lib/riscv64-linux-gnu',
+        '/usr/lib/powerpc64le-linux-gnu',
+        '/usr/lib/loongarch64-linux-gnu',
+        '/usr/lib/s390x-linux-gnu',
+        '/usr/lib/i386-linux-gnu',
+        '/usr/lib/arm-linux-gnueabi',
+        '/usr/lib/sparc64-linux-gnu',
+        '/usr/lib/mips64el-linux-gnuabi64',
     ]
 
     package_path_variant = _get_package_path_variant(package_path)


### PR DESCRIPTION
This patch fixes the following issue when attempting to load the glfw Python module on an unhandled architecture:

	Traceback (most recent call last):
	  File "/build/reproducible-path/python-pyglfw-2.8.0+dfsg/debian/tests/example.py", line 6, in <module>
	    import glfw
	  File "/build/reproducible-path/python-pyglfw-2.8.0+dfsg/.pybuild/cpython3_3.13/build/glfw/__init__.py", line 43, in <module>
	    raise ImportError("Failed to load GLFW3 shared library.")
	ImportError: Failed to load GLFW3 shared library.

Sure it might be cleaner to parse /etc/ld.so.conf, but it might also be more delicate to implement as well.

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1103102